### PR TITLE
Add missing quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ hexo.extend.renderer.register('ejs', 'html', function(data, options) {
     var path = options.filename = data.path;
     var content = data.text;
     if (!isEmpty(hexo.config.mathjax) && !isEmpty(hexo.config.mathjax.cdn)) {
-        content = content.replace(bodyTag, mathjaxScript +'\n' +'<script src=' + hexo.config.mathjax.cdn + '?config=TeX-AMS-MML_HTMLorMML></script>' +'\n' + bodyTag);
+        content = content.replace(bodyTag, mathjaxScript +'\n' +'<script src="' + hexo.config.mathjax.cdn + '?config=TeX-AMS-MML_HTMLorMML"></script>' +'\n' + bodyTag);
     }else{
         content = content.replace(bodyTag, mathjaxScript
         +'<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>' +'\n' + bodyTag);


### PR DESCRIPTION
Add missing quotes.
Quotes are missing from the `a` tag, resulting in invalid HTML.